### PR TITLE
feat: emit cloned repo path for git alias integration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,6 +160,9 @@ main() {
     log_info "git-mirror has been installed to: ${INSTALL_DIR}/${BINARY_NAME}"
     log_info ""
 
+    # Configure git alias
+    configure_git_alias
+
     # Check if install directory is in PATH
     if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
         log_warn "Warning: ${INSTALL_DIR} is not in your PATH"
@@ -174,6 +177,34 @@ main() {
     else
         log_info "Run 'git-mirror --help' to get started!"
     fi
+}
+
+# Configure git alias for mirror command
+configure_git_alias() {
+    log_info "Configuring git alias..."
+
+    # Define the alias command
+    ALIAS_CMD='!git-mirror "$@" && cd "$_"'
+
+    # Check if mirror alias already exists
+    EXISTING_ALIAS=$(git config --global alias.mirror 2>/dev/null || echo "")
+
+    if [ -n "$EXISTING_ALIAS" ]; then
+        log_warn "Git alias 'mirror' already exists: $EXISTING_ALIAS"
+        log_info "Would you like to update it to: $ALIAS_CMD"
+        log_info "To update manually, run: git config --global alias.mirror '$ALIAS_CMD'"
+    else
+        # Add the alias
+        if git config --global alias.mirror "$ALIAS_CMD"; then
+            log_info "✓ Git alias 'mirror' configured successfully!"
+            log_info "You can now use: git mirror <repo-url>"
+        else
+            log_warn "Failed to configure git alias. You can add it manually:"
+            log_info "  git config --global alias.mirror '$ALIAS_CMD'"
+        fi
+    fi
+
+    log_info ""
 }
 
 main "$@"

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,4 +160,7 @@ fn main() {
         )
         .cyan()
     );
+
+    // Emit the path for use in shell aliases (e.g., mirror = "!git-mirror && cd $_")
+    println!("{}", local.display());
 }


### PR DESCRIPTION
## Summary

This PR enables git-mirror to emit the cloned repository path, allowing users to create a convenient git alias that clones and changes directory in one command.

## Changes

- **src/main.rs**: Print the cloned repository path to stdout after successful cloning
- **install.sh**: Add automatic git alias configuration during installation

## Usage

After installing, users can use:
```bash
git mirror <repo-url>  # clones and automatically cds into the repo
```

Or manually add to ~/.gitconfig:
```ini
[alias]
    mirror = "!git-mirror \"$@\" && cd \"$_\""
```

## Technical Details

- The tool now prints the full path to the cloned directory as the final output
- The install script detects existing aliases and warns before overwriting
- The alias uses shell's `$_` variable to capture the last argument (the path)