### PR TITLE
docs: Add badges and LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 thoroc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # git-mirror
 
 [![CI](https://github.com/thoroc/git-mirror/actions/workflows/ci.yml/badge.svg)](https://github.com/thoroc/git-mirror/actions/workflows/ci.yml)
+[![Version](https://img.shields.io/badge/version-0.4.0-blue)](https://github.com/thoroc/git-mirror/releases)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Rust](https://img.shields.io/badge/built%20with-Rust-orange)](https://www.rust-lang.org/)
 
 Rust CLI to clone a GitHub/GitLab (or other Git) repo to `~/Projects` while keeping a tree
 structure close to the remote URL. If the project already exists locally the CLI can
 be used to print commands for updating or changing directory instead of cloning.
+
+## Why use git-mirror?
+
+Organizing cloned repositories consistently is tedious. git-mirror automates this by:
+
+- **Smart directory structure** - Mirrors the remote URL structure locally (`~/Projects/github/owner/repo`)
+- **Works with any Git host** - GitHub, GitLab, Bitbucket, or self-hosted instances
+- **Shell integration** - Print `cd` commands to jump straight into cloned repos
+- **VS Code ready** - Optionally open repos in VS Code immediately after cloning
+- **Fast and lightweight** - Written in Rust for maximum performance
 
 ## Install
 


### PR DESCRIPTION
## Summary

This PR improves the README appearance and adds a proper LICENSE file.

### Changes

- Added status badges (version, license, Rust) to README header
- Added "Why use git-mirror?" section with key features highlighted
- Created MIT LICENSE file to match the license badge

### Checklist

- [x] README badges added
- [x] Why use section added
- [x] LICENSE file created