### PR TITLE
fix(ci): correct release-please output variable name

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.publish_release.outputs.release_created }}
+      releases_created: ${{ steps.publish_release.outputs.releases_created }}
       tag_name: ${{ steps.publish_release.outputs.tag_name }}
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
 
   build_and_upload:
     needs: release
-    if: needs.release.outputs.release_created == 'true'
+    if: needs.release.outputs.releases_created == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Fixes the release workflow so that build artifacts are properly uploaded to releases.

## Problem

The `build_and_upload` job was never triggered because it checked for `release_created` output, but release-please-action v4 outputs `releases_created` (plural).

## Changes

- Changed `release_created` to `releases_created` in job outputs (line 17)
- Updated job condition check from `release_created` to `releases_created` (line 35)

## Testing

This fix ensures the `build_and_upload` job will run when release-please creates a release, building and uploading binaries for:
- Linux (x86_64, aarch64)
- macOS (x86_64, aarch64)  
- Windows (x86_64)

Fixes missing release assets issue.