### PR TITLE
fix: add GH_TOKEN to upload release artifacts step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Upload release artifacts
         env:
           TAG: ${{ needs.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           gh release upload "${{ env.TAG }}" ${{ matrix.archive_name }} ${{ matrix.archive_name }}.sha256 --clobber
         shell: bash


### PR DESCRIPTION
Adds missing GH_TOKEN environment variable to the 'Upload release artifacts' step so the gh CLI can authenticate when uploading release binaries.