### PR TITLE
fix: make releases immutable by removing --clobber flag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Upload release artifacts
         env:
           TAG: ${{ needs.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           gh release upload "${{ env.TAG }}" ${{ matrix.archive_name }} ${{ matrix.archive_name }}.sha256 --clobber
         shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -137,5 +137,5 @@ jobs:
           TAG: ${{ needs.release.outputs.tag_name }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          gh release upload "${{ env.TAG }}" ${{ matrix.archive_name }} ${{ matrix.archive_name }}.sha256 --clobber
+          gh release upload "${{ env.TAG }}" ${{ matrix.archive_name }} ${{ matrix.archive_name }}.sha256
         shell: bash


### PR DESCRIPTION
Removes the --clobber flag from gh release upload to ensure releases are immutable. Once artifacts are uploaded, they cannot be overwritten.