### PR TITLE
fix: use release_created (singular) output for release-please v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tests/**'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      releases_created: ${{ steps.publish_release.outputs.releases_created }}
+      release_created: ${{ steps.publish_release.outputs.release_created }}
       tag_name: ${{ steps.publish_release.outputs.tag_name }}
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
 
   build_and_upload:
     needs: release
-    if: needs.release.outputs.releases_created == 'true'
+    if: needs.release.outputs.release_created == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Fixes the release workflow by using the correct output name. In release-please-action v4, `releases_created` (plural) is broken and always returns true. Must use `release_created` (singular) instead.