### PR TITLE
fix: create release after building assets for immutability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tests/**'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,13 +22,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create or update Release PR and GitHub Release (release-please)
+      - name: Create or update Release PR (release-please)
         id: publish_release
         uses: googleapis/release-please-action@v4
         with:
           release-type: rust
           package-name: git-mirror
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          skip-github-release: true
 
   build_and_upload:
     needs: release
@@ -132,10 +133,32 @@ jobs:
         run: |
           echo "GitHub CLI will use GH_TOKEN environment variable for authentication"
 
-      - name: Upload release artifacts
+      - name: Upload artifacts to workflow
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.archive_name }}
+          path: |
+            ${{ matrix.archive_name }}
+            ${{ matrix.archive_name }}.sha256
+
+  create_release:
+    needs: [release, build_and_upload]
+    if: needs.release.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+          merge-multiple: true
+
+      - name: Create release and upload assets
         env:
           TAG: ${{ needs.release.outputs.tag_name }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          gh release upload "${{ env.TAG }}" ${{ matrix.archive_name }} ${{ matrix.archive_name }}.sha256
-        shell: bash
+          cd ./artifacts
+          gh release create "${{ env.TAG }}" \
+            --title "Release ${{ env.TAG }}" \
+            --generate-notes \
+            *.tar.gz *.zip *.sha256

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      releases_created: ${{ steps.publish_release.outputs.releases_created }}
+      release_created: ${{ steps.publish_release.outputs.release_created }}
       tag_name: ${{ steps.publish_release.outputs.tag_name }}
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
 
   build_and_upload:
     needs: release
-    if: needs.release.outputs.releases_created == 'true'
+    if: needs.release.outputs.release_created == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Fixes immutable release creation by:\n\n1. Using `skip-github-release: true` in release-please-action to prevent creating the release prematurely\n2. Building all binaries across matrix platforms\n3. Uploading artifacts using actions/upload-artifact@v4\n4. Creating the GitHub release with all assets in a final job using gh release create\n\nThis ensures the release is created atomically with all assets, preventing the "Cannot upload assets to an immutable release" error.