### PR TITLE
fix: correct output reference and tag construction for immutable releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       paths_released: ${{ steps.publish_release.outputs.paths_released }}
-      tag_name: v${{ steps.publish_release.outputs.version }}
+      version: ${{ steps.publish_release.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -154,11 +154,12 @@ jobs:
 
       - name: Create release and upload assets
         env:
-          TAG: ${{ needs.release.outputs.tag_name }}
+          VERSION: ${{ needs.release.outputs.version }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           cd ./artifacts
-          gh release create "${{ env.TAG }}" \
-            --title "Release ${{ env.TAG }}" \
+          TAG="v${VERSION}"
+          gh release create "${TAG}" \
+            --title "Release ${TAG}" \
             --generate-notes \
             *.tar.gz *.zip *.sha256


### PR DESCRIPTION
## Problem\nThe release workflow failed because:\n1. Job outputs cannot construct strings with prefixes like `v${{ ... }}` - this is invalid GitHub Actions syntax\n2. Shell variables were not being expanded properly in `gh release create`\n\n## Solution\n- Export only `version` (e.g., 0.4.5) from the release job\n- Construct tag with `v` prefix in the create_release job shell script\n- Use proper shell variable expansion (`${TAG}` instead of `${{ env.TAG }}`)\n\nThis ensures immutable releases work correctly with pre-built assets.