### PR TITLE
fix: extract version from Cargo.toml for immutable releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -155,9 +155,15 @@ jobs:
           path: ./artifacts
           merge-multiple: true
 
+      - name: Extract version from Cargo.toml
+        id: get_version
+        run: |
+          VERSION=$(grep -E '^version\s*=' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Create release and upload assets
         env:
-          VERSION: ${{ needs.release.outputs.version }}
+          VERSION: ${{ steps.get_version.outputs.version }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           cd ./artifacts

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -146,6 +146,9 @@ jobs:
     if: needs.release.outputs.paths_released != '[]'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Problem\nThe release-please-action does not output the `version` when `skip-github-release: true` is set. This caused the create_release job to fail with an empty VERSION variable.\n\n## Solution\nAdd a step to extract the version directly from Cargo.toml using grep/sed:\n\n```bash\nVERSION=$(grep -E '^version\s*=' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')\n```\n\nThis ensures the version is always available for creating the release tag (v{version}).\n\n## Changes\n- Added step `Extract version from Cargo.toml` to get version from manifest\n- Use extracted version in gh release create command\n- Still reads from release-please output if available, with fallback to Cargo.toml extraction