### PR TITLE
fix: add shell: bash to version extraction steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Extract version from Cargo.toml
         id: get_version
+        shell: bash
         run: |
           VERSION=$(grep -E '^version\s*=' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
@@ -170,6 +171,7 @@ jobs:
 
       - name: Extract version from Cargo.toml
         id: get_version
+        shell: bash
         run: |
           VERSION=$(grep -E '^version\s*=' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem\nThe "Extract version from Cargo.toml" step failed on Windows with:\n\n```\nThe module 'VERSION=$(grep -E '^version' could not be loaded.\n```\n\nThis is because Windows runners default to PowerShell, not bash.\n\n## Solution\nAdded `shell: bash` to both "Extract version from Cargo.toml" steps to ensure the bash commands run correctly across all platforms (Linux, macOS, and Windows).