### PR TITLE
fix: handle existing releases when creating with artifacts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -183,6 +183,14 @@ jobs:
         run: |
           cd ./artifacts
           TAG="v${VERSION}"
+          
+          # Check if release already exists and delete it (it was created without artifacts)
+          if gh release view "${TAG}" &>/dev/null; then
+            echo "Release ${TAG} already exists, deleting it to recreate with artifacts..."
+            gh release delete "${TAG}" --yes
+          fi
+          
+          # Create the release with all artifacts
           gh release create "${TAG}" \
             --title "Release ${TAG}" \
             --generate-notes \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Extract version from Cargo.toml
         id: get_version
+        shell: bash
         run: |
           VERSION=$(grep -E '^version\s*=' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
@@ -170,6 +171,7 @@ jobs:
 
       - name: Extract version from Cargo.toml
         id: get_version
+        shell: bash
         run: |
           VERSION=$(grep -E '^version\s*=' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem\nThe workflow failed because release v0.4.5 already existed from a previous failed run, causing `gh release create` to fail with "a release with the same tag name already exists".\n\n## Solution\nAdded logic to check if a release already exists and delete it before recreating with all artifacts:\n\n```bash\nif gh release view "${TAG}" &>/dev/null; then\n  echo "Release ${TAG} already exists, deleting it to recreate with artifacts..."\n  gh release delete "${TAG}" --yes\nfi\n```\n\nThis ensures the release is atomic with all artifacts, handling retries and failed partial runs gracefully.