### PR TITLE
fix: skip release creation if immutable release already exists

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -184,10 +184,11 @@ jobs:
           cd ./artifacts
           TAG="v${VERSION}"
           
-          # Check if release already exists and delete it (it was created without artifacts)
+          # Check if release already exists
           if gh release view "${TAG}" &>/dev/null; then
-            echo "Release ${TAG} already exists, deleting it to recreate with artifacts..."
-            gh release delete "${TAG}" --yes
+            echo "Release ${TAG} already exists (immutable). Skipping release creation."
+            echo "Note: Artifacts were built but cannot be uploaded to existing immutable release."
+            exit 0
           fi
           
           # Create the release with all artifacts


### PR DESCRIPTION
## Problem\nThe workflow failed because release v0.4.5 already exists as an immutable release and cannot be deleted or modified.\n\n## Solution\nInstead of trying to delete the existing release (which fails for immutable releases), we now check if the release exists and gracefully skip creation with a warning:\n\n```bash\nif gh release view "${TAG}" &>/dev/null; then\n  echo "Release ${TAG} already exists (immutable). Skipping release creation."\n  echo "Note: Artifacts were built but cannot be uploaded to existing immutable release."\n  exit 0\nfi\n```\n\n## Note\nThe v0.4.5 release exists from before our immutable release fix. Future releases will work correctly since release-please won't create them early (with `skip-github-release: true`). To fix v0.4.5, you would need to manually delete it from the GitHub UI and re-run the workflow.