### PR TITLE
chore: bump version to 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.6](https://github.com/thoroc/git-mirror/compare/v0.4.5...v0.4.6) (2026-02-07)
+
+
+### Bug Fixes
+
+* skip release creation if immutable release already exists ([#25](https://github.com/thoroc/git-mirror/issues/25))
+* handle existing releases when creating with artifacts ([#24](https://github.com/thoroc/git-mirror/issues/24))
+* add shell: bash to version extraction steps ([#23](https://github.com/thoroc/git-mirror/issues/23))
+* extract version from Cargo.toml for immutable releases ([#21](https://github.com/thoroc/git-mirror/issues/21))
+
 ## [0.4.5](https://github.com/thoroc/git-mirror/compare/v0.4.4...v0.4.5) (2026-02-06)
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-mirror"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Bump version from 0.4.5 to 0.4.6 to trigger a fresh release with all the recent workflow fixes.

## Changes

- Bumped version in Cargo.toml from 0.4.5 to 0.4.6
- Updated CHANGELOG.md with new release notes

## Notes

The v0.4.5 release already exists as immutable (from before our workflow fixes), so we need v0.4.6 to test the complete release pipeline with binary artifacts.