### PR TITLE
fix: include version in archive name for install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ main() {
         EXT="tar.gz"
     fi
 
-    ARCHIVE_NAME="${BINARY_NAME%.*}-${OS}-${ARCH}.${EXT}"
+    ARCHIVE_NAME="${BINARY_NAME%.*}-${OS}-${ARCH}-${VERSION}.${EXT}"
 
     # Get latest version
     log_info "Fetching latest release version..."


### PR DESCRIPTION
## Problem
The install script failed to download the archive because it was constructing the filename without the version number.

Script was looking for: 
Actual artifact is: 

## Solution
Updated the archive name construction in install.sh to include the version:


This ensures the install script can correctly download versioned release artifacts.