### PR TITLE
fix: correct variable order in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,15 +73,13 @@ main() {
     log_info "Detected OS: $OS"
     log_info "Detected architecture: $ARCH"
 
-    # Determine file extension and archive name
+    # Determine file extension
     if [ "$OS" = "windows" ]; then
         EXT="zip"
         BINARY_NAME="git-mirror.exe"
     else
         EXT="tar.gz"
     fi
-
-    ARCHIVE_NAME="${BINARY_NAME%.*}-${OS}-${ARCH}-${VERSION}.${EXT}"
 
     # Get latest version
     log_info "Fetching latest release version..."
@@ -93,6 +91,9 @@ main() {
     fi
 
     log_info "Latest version: $VERSION"
+
+    # Construct archive name after VERSION is known
+    ARCHIVE_NAME="${BINARY_NAME%.*}-${OS}-${ARCH}-${VERSION}.${EXT}"
 
     # Download URL
     DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE_NAME}"

--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ main() {
         EXT="tar.gz"
     fi
 
-    ARCHIVE_NAME="${BINARY_NAME%.*}-${OS}-${ARCH}.${EXT}"
+    ARCHIVE_NAME="${BINARY_NAME%.*}-${OS}-${ARCH}-${VERSION}.${EXT}"
 
     # Get latest version
     log_info "Fetching latest release version..."


### PR DESCRIPTION
## Problem
The install script had a variable ordering bug where VERSION was used in ARCHIVE_NAME construction (line 84) before VERSION was actually fetched (line 88), causing the download URL to be malformed.

## Solution
Moved the VERSION fetch before the ARCHIVE_NAME construction to ensure the version is available when constructing the download URL.

## Testing
Tested locally on macOS/ARM - script now successfully downloads and installs git-mirror v0.4.6.